### PR TITLE
upgrade libsquash; fix #18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## v0.9.4
 
 - add option --clean to clean temporary files before compiling
-- upgrade libsquash to https://github.com/pmq20/libsquash/commit/f89d88ed9c59e5726874ed35b528a15d20ec1188
+- fix #18: https://github.com/pmq20/node-compiler/issues/18
+- upgrade libsquash to https://github.com/pmq20/libsquash/commit/e8441d3f0dd10af5e3b56bd89ec7097f303ae2d3
 
 ## v0.9.3
 

--- a/node/deps/libsquash/sample/enclose_io_common.h
+++ b/node/deps/libsquash/sample/enclose_io_common.h
@@ -108,6 +108,8 @@ int enclose_io_fstat(int fildes, struct stat *buf);
 int enclose_io_open(int nargs, const char *pathname, int flags, ...);
 int enclose_io_close(int fildes);
 ssize_t enclose_io_read(int fildes, void *buf, size_t nbyte);
+ssize_t enclose_io_pread(int d, void *buf, size_t nbyte, off_t offset);
+ssize_t enclose_io_readv(int d, const struct iovec *iov, int iovcnt);
 off_t enclose_io_lseek(int fildes, off_t offset, int whence);
 
 #ifdef _WIN32

--- a/node/deps/libsquash/sample/enclose_io_unix.h
+++ b/node/deps/libsquash/sample/enclose_io_unix.h
@@ -10,33 +10,36 @@
 #define ENCLOSE_IO_UNIX_H_E0229A03
 #ifndef __cplusplus
 
-#ifndef RUBY_WIN32_H
-#define chdir(...) enclose_io_chdir(__VA_ARGS__)
-#define getcwd(...) enclose_io_getcwd(__VA_ARGS__)
-#define stat(...)	enclose_io_stat(__VA_ARGS__)
-#define fstat(...)	enclose_io_fstat(__VA_ARGS__)
-#define open(...)	enclose_io_open(ENCLOSE_IO_PP_NARG(__VA_ARGS__), __VA_ARGS__)
-#define close(...)	enclose_io_close(__VA_ARGS__)
-#define read(...)	enclose_io_read(__VA_ARGS__)
-#define lseek(...)	enclose_io_lseek(__VA_ARGS__)
-#endif // !RUBY_WIN32_H
+#define chdir(...)	enclose_io_chdir(__VA_ARGS__)
+#define pread(...)	enclose_io_pread(__VA_ARGS__)
+
+#ifndef RUBY_EXPORT
+	#define getcwd(...)	enclose_io_getcwd(__VA_ARGS__)
+	#define stat(...)	enclose_io_stat(__VA_ARGS__)
+	#define fstat(...)	enclose_io_fstat(__VA_ARGS__)
+	#define open(...)	enclose_io_open(ENCLOSE_IO_PP_NARG(__VA_ARGS__), __VA_ARGS__)
+	#define close(...)	enclose_io_close(__VA_ARGS__)
+	#define read(...)	enclose_io_read(__VA_ARGS__)
+	#define lseek(...)	enclose_io_lseek(__VA_ARGS__)
+#endif // !RUBY_EXPORT
 
 #ifndef _WIN32
 
-#ifdef dirfd
-#undef dirfd
-#endif
-#define getwd(...) enclose_io_getwd(__VA_ARGS__)
-#define lstat(...)	enclose_io_lstat(__VA_ARGS__)
-#define readlink(...) enclose_io_readlink(__VA_ARGS__)
-#define opendir(...)	enclose_io_opendir(__VA_ARGS__)
-#define closedir(...)	enclose_io_closedir(__VA_ARGS__)
-#define readdir(...)	enclose_io_readdir(__VA_ARGS__)
-#define telldir(...)	enclose_io_telldir(__VA_ARGS__)
-#define seekdir(...)	enclose_io_seekdir(__VA_ARGS__)
-#define rewinddir(...)	enclose_io_rewinddir(__VA_ARGS__)
-#define dirfd(...) enclose_io_dirfd(__VA_ARGS__)
-#define scandir(...)	enclose_io_scandir(__VA_ARGS__)
+	#ifdef dirfd
+		#undef dirfd
+	#endif
+	#define getwd(...)	enclose_io_getwd(__VA_ARGS__)
+	#define lstat(...)	enclose_io_lstat(__VA_ARGS__)
+	#define readlink(...)	enclose_io_readlink(__VA_ARGS__)
+	#define opendir(...)	enclose_io_opendir(__VA_ARGS__)
+	#define closedir(...)	enclose_io_closedir(__VA_ARGS__)
+	#define readdir(...)	enclose_io_readdir(__VA_ARGS__)
+	#define telldir(...)	enclose_io_telldir(__VA_ARGS__)
+	#define seekdir(...)	enclose_io_seekdir(__VA_ARGS__)
+	#define rewinddir(...)	enclose_io_rewinddir(__VA_ARGS__)
+	#define dirfd(...)	enclose_io_dirfd(__VA_ARGS__)
+	#define scandir(...)	enclose_io_scandir(__VA_ARGS__)
+	#define readv(...)	enclose_io_readv(__VA_ARGS__)
 
 #endif // !_WIN32
 


### PR DESCRIPTION
Node.js takes use of all three read system calls, i.e., pread, read, readv, yet libsquash only intercepted one of them: read.

Fixed in libsquash: https://github.com/pmq20/libsquash/commit/e8441d3f0dd10af5e3b56bd89ec7097f303ae2d3